### PR TITLE
テキスト教材のCSVインポート機能を実装

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
+require "csv"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
@@ -23,6 +24,8 @@ module TeamProject
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+
+    config.autoload_paths << Rails.root.join("lib/autoloads")
 
     config.i18n.default_locale = :ja
     config.time_zone = "Asia/Tokyo"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,8 @@
-EMAIL = 'test@example.com'
-PASSWORD = 'password'
+EMAIL = "test@example.com"
+PASSWORD = "password"
 
 # テストユーザーが存在しないときだけ作成
 User.find_or_create_by!(email: EMAIL) do |user|
   user.password = PASSWORD
-  puts 'ユーザーの初期データインポートに成功しました。'
+  puts "ユーザーの初期データインポートに成功しました。"
 end

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -1,0 +1,16 @@
+class ImportCsv
+  def self.import(path)
+    list = []
+    CSV.foreach(path, headers: true) do |row|
+      list << row.to_h
+    end
+    list
+  end
+
+  def self.text_data
+    list = import("db/csv_data/text_data.csv")
+    puts "インポート処理を開始"
+    Text.create!(list)
+    puts "インポート完了！！"
+  end
+end


### PR DESCRIPTION
## issue 番号（必須）
​close #18

## 実装内容
​db/seeds.rb に，テキスト教材のCSV（db/csv_data/text_data.csv）を読み込み texts テーブルにデータを投入する処理を追加

## 参考資料


- やんばるCODE教材（CSVインポート）
  - https://arcane-gorge-21903.herokuapp.com/texts/217
​
## チェックリスト
​
【補足】プルリクを出した後，クリックでチェックを入れて下さい
​
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
​
## スクリーンショット（必要があれば）
​
​
## 備考（必要があれば）
