### PR TITLE
動画教材のCSVインポート機能の実装

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
-
+require "csv"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -23,7 +23,8 @@ module TeamProject
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
-
+    # lib/autoloads ディレクトリ配下のファイルを読み込む
+    config.autoload_paths << Rails.root.join("lib/autoloads")
     config.i18n.default_locale = :ja
     config.time_zone = "Asia/Tokyo"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,5 +7,8 @@ User.find_or_create_by!(email: EMAIL) do |user|
   puts "ユーザーの初期データインポートに成功しました。"
 end
 
- Movie .destroy＿all
- ImportCsv .movie＿data
+ Movie.destroy_all
+ Text.destroy_all
+
+ ImportCsv.movie_data
+ ImportCsv.text_date

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,3 +6,6 @@ User.find_or_create_by!(email: EMAIL) do |user|
   user.password = PASSWORD
   puts "ユーザーの初期データインポートに成功しました。"
 end
+
+ Movie .destroy＿all
+ ImportCsv .movie＿data

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -1,12 +1,18 @@
 class ImportCsv
   # CSVデータのパスを引数として受け取り、インポート処理を実行
   def self.import(path)
-     CSV.foreach(path, headers: true) do |row|
-       Post.create!(
-         genre: row["genre"],
-         title: row["title"],
-         url: row["url"]
-       )
-     end
+    list = []
+    CSV.foreach(path, headers: true) do |row|
+      list << row.to_h
+    end
+    list
+  end
+
+  def self.movie_data
+    list =  import('db/csv_data/movie_data.csv')
+
+    puts "インポート処理を開始"
+    Movie.create!(list)
+    puts "インポート完了"
   end
 end

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -2,7 +2,7 @@ class ImportCsv
   # CSVデータのパスを引数として受け取り、インポート処理を実行
   def self.import(path)
      CSV.foreach(path, headers: true) do |row|
-       User.create!(
+       Post.create!(
          genre: row["genre"],
          title: row["title"],
          url: row["url"]

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -1,6 +1,7 @@
 class ImportCsv
   # CSVデータのパスを引数として受け取り、インポート処理を実行
   def self.import(path)
+    # 空の配列を格納
     list = []
     CSV.foreach(path, headers: true) do |row|
       list << row.to_h
@@ -10,7 +11,6 @@ class ImportCsv
 
   def self.movie_data
     list =  import('db/csv_data/movie_data.csv')
-
     puts "インポート処理を開始"
     Movie.create!(list)
     puts "インポート完了"

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -1,0 +1,12 @@
+class ImportCsv
+  # CSVデータのパスを引数として受け取り、インポート処理を実行
+  def self.import(path)
+     CSV.foreach(path, headers: true) do |row|
+       User.create!(
+         genre: row["genre"],
+         title: row["title"],
+         url: row["url"]
+       )
+     end
+  end
+end


### PR DESCRIPTION

close #2 
​
## 実装内容
​
​
- db/seeds.rb に，テキスト教材のCSV（db/csv_data/movie_data.csv）を読み込み movies テーブルにデータを投入する処理を追加
  
## 参考資料
​
- ログイン機能
  - [やんばる教材　CSVインポート](https://www.yanbaru-code.com/texts/217)
​
## チェックリスト
​
【補足】プルリクを出した後，クリックでチェックを入れて下さい
​
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
​
## スクリーンショット（必要があれば）
​
​
## 備考（必要があれば）
