### PR TITLE
Railsテキスト教材一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,7 +27,7 @@ body {
    text-align: center;
  }
 
- .col-12 {
+ .text-card-container {
     padding-left: 9px;
     padding-right: 9px;
    margin-bottom: 50px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,14 @@ body {
    font-size: 0.8rem;
  }
 
+ .text-title {
+   text-align: center;
+ }
+
+ .card {
+   margin: 30px, 15px;
+ }
+
 /* max-width */
 
 .mw-md {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,14 +27,10 @@ body {
    text-align: center;
  }
 
- .card {
-   margin-bottom: 50px;
- }
-
  .col-12 {
     padding-left: 9px;
     padding-right: 9px;
-    
+   margin-bottom: 50px;
  }
 
 /* max-width */

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,9 +28,13 @@ body {
  }
 
  .card {
-   margin-left: 9px;
-   margin-right: 9px;
    margin-bottom: 50px;
+ }
+
+ .col-12 {
+    padding-left: 9px;
+    padding-right: 9px;
+    
  }
 
 /* max-width */

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,7 +28,9 @@ body {
  }
 
  .card {
-   margin: 30px, 15px;
+   margin-left: 9px;
+   margin-right: 9px;
+   margin-bottom: 50px;
  }
 
 /* max-width */

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-dark mw-lg mx-auto">
-  <a class="navbar-brand" href="#">やんばるCODE</a>
+  <a class="navbar-brand" href="/">やんばるCODE</a>
   <button class="navbar-toggler active" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
@@ -10,7 +10,7 @@
           Rails
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-          <a class="dropdown-item" href="#">Ruby/Rails教材</a>
+          <a class="dropdown-item" href="/">Ruby/Rails教材</a>
           <a class="dropdown-item" href="#">動画教材</a>
           <a class="dropdown-item" href="#">AWS講座</a>
           <a class="dropdown-item" href="#">プログラミング勉強会</a>
@@ -32,7 +32,7 @@
           フロント
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-          <a class="dropdown-item" href="#">HTML&CSS</a>
+          <a class="dropdown-item" href="/">HTML&CSS</a>
           <a class="dropdown-item" href="#">JavaScript</a>
           <a class="dropdown-item" href="#">TypeScript</a>
           <a class="dropdown-item" href="#">Angular</a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
         </div>
         <div class="container">
           <div class="row">
-            <div class="card col-lg-4 col-md-6">
+            <div class="col-12 card col-lg-4 col-md-6">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,532 +20,664 @@
         </div>
         <div class="container">
           <div class="row">
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Macのショートカットキー</p>
-                <p class="card-text">【Basic】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Linuxコマンド</p>
-                <p class="card-text">【Basic】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Slackを使用したいろんなマークダウン記法</p>
-                <p class="card-text">【Basic】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Ruby on Rails の環境構築（Mac版）</p>
-                <p class="card-text">【Basic】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Ruby on Rails 環境構築手順（Windows版）</p>
-                <p class="card-text">【Basic】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">環境構築（VSCode）</p>
-                <p class="card-text">【Basic】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Atomの便利な使い方</p>
-                <p class="card-text">【Basic】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">超便利なMarkdownの基礎</p>
-                <p class="card-text">【Basic】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">現場でやったらあかんこと</p>
-                <p class="card-text">【Basic】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Gitとは</p>
-                <p class="card-text">【Git】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Git基本の流れ</p>
-                <p class="card-text">【Git】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Vimの使い方</p>
-                <p class="card-text">【Git】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Gitコマンド一覧・具体的な対処例</p>
-                <p class="card-text">【Git】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">GitとGithubを利用した共同開発</p>
-                <p class="card-text">【Git】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">入出力を行うためのメソッド一覧</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">変数</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">条件分岐</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">メソッド</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">配列</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">繰り返し処理</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">ハッシュ</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">オブジェクト指向</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">CSVインポート</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">CSVファイルの生成</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">RSpec</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">八百屋プログラム（条件分岐）part1</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">八百屋プログラム（メソッド）part2</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">八百屋プログラム（クラス）part3</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">YouTube検索を実装するAPI</p>
-                <p class="card-text">【Ruby】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Ruby on Rails の基本</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Ruby on Rails で Hellow World!!</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">アプリのデプロイ（Heroku）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">SQLの基礎</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">CRUDの処理の実装</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Active Recordの様々なメソッド</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Active Recordの様々な削除メソッド</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">resources を使ったCRUD処理の実装</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">デバッグツール（binding.pry）の使い方</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">メッセージ投稿アプリ（その1・CRUD処理）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">メッセージ投稿アプリ（その2・エラー処理）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">メッセージ投稿アプリ（その3・Bootstrap）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Rails Best Practice の導入</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Bootstrap の導入</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">CSVデータインポート機能</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Rakeタスク</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">ログイン機能</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">管理者画面</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">オリジナル管理者画面</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">お問い合わせフォーム</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">モデルの関連付け その1（1対多）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">モデルの関連付け その2（多対多）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">検索機能</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">画像投稿機能</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Herokuの画像投稿設定（その1・IAM S3）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Herokuの画像投稿設定（その2・CarrierWave）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">Herokuの画像投稿設定（その3・CloudFront）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">CSVインポート・エクスポート機能</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">テストコードの実装（RSpec）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">RailsアプリへのMarkdownの導入</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">RSpec（準備）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">RSpec（factory_bot_railsの基礎）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">RSpec（モデルスペック）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">RSpec（リクエストスペック）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">データをグラフ化してみよう！（Rails 6）</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">ActionCableを使用したチャットアプリ</p>
-                <p class="card-text">【Ruby on Rails】</p>
-              </div>
-            </div>
-            <div class="card col-12 col-md-6 col-lg-4">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <a href="#" class="btn btn-primary">Go somewhere</a>
-                <p class="card-text">【作ってみよう！】体重管理アプリの実装</p>
-                <p class="card-text">【Ruby on Rails】</p>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Macのショートカットキー</p>
+                  <p class="card-text">【Basic】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Linuxコマンド</p>
+                  <p class="card-text">【Basic】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Slackを使用したいろんなマークダウン記法</p>
+                  <p class="card-text">【Basic】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Ruby on Rails の環境構築（Mac版）</p>
+                  <p class="card-text">【Basic】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Ruby on Rails 環境構築手順（Windows版）</p>
+                  <p class="card-text">【Basic】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">環境構築（VSCode）</p>
+                  <p class="card-text">【Basic】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Atomの便利な使い方</p>
+                  <p class="card-text">【Basic】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">超便利なMarkdownの基礎</p>
+                  <p class="card-text">【Basic】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">現場でやったらあかんこと</p>
+                  <p class="card-text">【Basic】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Gitとは</p>
+                  <p class="card-text">【Git】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Git基本の流れ</p>
+                  <p class="card-text">【Git】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Vimの使い方</p>
+                  <p class="card-text">【Git】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Gitコマンド一覧・具体的な対処例</p>
+                  <p class="card-text">【Git】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">GitとGithubを利用した共同開発</p>
+                  <p class="card-text">【Git】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">入出力を行うためのメソッド一覧</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">変数</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">条件分岐</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">メソッド</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">配列</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">繰り返し処理</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">ハッシュ</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">オブジェクト指向</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">CSVインポート</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">CSVファイルの生成</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">RSpec</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">八百屋プログラム（条件分岐）part1</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">八百屋プログラム（メソッド）part2</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">八百屋プログラム（クラス）part3</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">YouTube検索を実装するAPI</p>
+                  <p class="card-text">【Ruby】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Ruby on Rails の基本</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Ruby on Rails で Hellow World!!</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">アプリのデプロイ（Heroku）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">SQLの基礎</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">CRUDの処理の実装</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Active Recordの様々なメソッド</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Active Recordの様々な削除メソッド</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">resources を使ったCRUD処理の実装</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">デバッグツール（binding.pry）の使い方</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">メッセージ投稿アプリ（その1・CRUD処理）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">メッセージ投稿アプリ（その2・エラー処理）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">メッセージ投稿アプリ（その3・Bootstrap）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Rails Best Practice の導入</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Bootstrap の導入</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">CSVデータインポート機能</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Rakeタスク</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">ログイン機能</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">管理者画面</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">オリジナル管理者画面</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">お問い合わせフォーム</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">モデルの関連付け その1（1対多）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">モデルの関連付け その2（多対多）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">検索機能</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">画像投稿機能</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Herokuの画像投稿設定（その1・IAM S3）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Herokuの画像投稿設定（その2・CarrierWave）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">Herokuの画像投稿設定（その3・CloudFront）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">CSVインポート・エクスポート機能</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">テストコードの実装（RSpec）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">RailsアプリへのMarkdownの導入</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">RSpec（準備）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">RSpec（factory_bot_railsの基礎）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">RSpec（モデルスペック）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">RSpec（リクエストスペック）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">データをグラフ化してみよう！（Rails 6）</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">ActionCableを使用したチャットアプリ</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 col-md-6 col-lg-4 text-card-container">
+              <div class="card">
+                <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+                <div class="card-body">
+                  <a href="#" class="btn btn-primary">Go somewhere</a>
+                  <p class="card-text">【作ってみよう！】体重管理アプリの実装</p>
+                  <p class="card-text">【Ruby on Rails】</p>
+                </div>
               </div>
             </div>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,9 @@
     <main>
       <%# max_width メソッドは application_helper.rb に記載 %>
       <div class="base-container <%= max_width %>">
-        <h2>Rails テキスト教材</h2>
+        <div class="text-title">
+          <h3>Rails テキスト教材</h3>
+        </div>
         <div class="container">
           <div class="row">
             <div class="card col-lg-4 col-md-6">
@@ -42,8 +44,6 @@
                 <p class="card-text">【Basic】</p>
               </div>
             </div>
-          </div>
-          <div class="row">
             <div class="card col-lg-4 col-md-6">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
@@ -66,6 +66,486 @@
                 <a href="#" class="btn btn-primary">Go somewhere</a>
                 <p class="card-text">環境構築（VSCode）</p>
                 <p class="card-text">【Basic】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Atomの便利な使い方</p>
+                <p class="card-text">【Basic】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">超便利なMarkdownの基礎</p>
+                <p class="card-text">【Basic】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">現場でやったらあかんこと</p>
+                <p class="card-text">【Basic】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Gitとは</p>
+                <p class="card-text">【Git】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Git基本の流れ</p>
+                <p class="card-text">【Git】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Vimの使い方</p>
+                <p class="card-text">【Git】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Gitコマンド一覧・具体的な対処例</p>
+                <p class="card-text">【Git】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">GitとGithubを利用した共同開発</p>
+                <p class="card-text">【Git】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">入出力を行うためのメソッド一覧</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">変数</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">条件分岐</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">メソッド</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">配列</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">繰り返し処理</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">ハッシュ</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">オブジェクト指向</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">CSVインポート</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">CSVファイルの生成</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">RSpec</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">八百屋プログラム（条件分岐）part1</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">八百屋プログラム（メソッド）part2</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">八百屋プログラム（クラス）part3</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">YouTube検索を実装するAPI</p>
+                <p class="card-text">【Ruby】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Ruby on Rails の基本</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Ruby on Rails で Hellow World!!</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">アプリのデプロイ（Heroku）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">SQLの基礎</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">CRUDの処理の実装</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Active Recordの様々なメソッド</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Active Recordの様々な削除メソッド</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">resources を使ったCRUD処理の実装</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">デバッグツール（binding.pry）の使い方</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">メッセージ投稿アプリ（その1・CRUD処理）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">メッセージ投稿アプリ（その2・エラー処理）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">メッセージ投稿アプリ（その3・Bootstrap）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Rails Best Practice の導入</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Bootstrap の導入</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">CSVデータインポート機能</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Rakeタスク</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">ログイン機能</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">管理者画面</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">オリジナル管理者画面</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">お問い合わせフォーム</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">モデルの関連付け その1（1対多）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">モデルの関連付け その2（多対多）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">検索機能</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">画像投稿機能</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Herokuの画像投稿設定（その1・IAM S3）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Herokuの画像投稿設定（その2・CarrierWave）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Herokuの画像投稿設定（その3・CloudFront）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">CSVインポート・エクスポート機能</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">テストコードの実装（RSpec）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">RailsアプリへのMarkdownの導入</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">RSpec（準備）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">RSpec（factory_bot_railsの基礎）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">RSpec（モデルスペック）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">RSpec（リクエストスペック）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">データをグラフ化してみよう！（Rails 6）</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">ActionCableを使用したチャットアプリ</p>
+                <p class="card-text">【Ruby on Rails】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">【作ってみよう！】体重管理アプリの実装</p>
+                <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
         </div>
         <div class="container">
           <div class="row">
-            <div class="col-12 card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -28,7 +28,7 @@
                 <p class="card-text">【Basic】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -36,7 +36,7 @@
                 <p class="card-text">【Basic】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -44,7 +44,7 @@
                 <p class="card-text">【Basic】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -52,7 +52,7 @@
                 <p class="card-text">【Basic】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -60,7 +60,7 @@
                 <p class="card-text">【Basic】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -68,7 +68,7 @@
                 <p class="card-text">【Basic】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -76,7 +76,7 @@
                 <p class="card-text">【Basic】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -84,7 +84,7 @@
                 <p class="card-text">【Basic】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -92,7 +92,7 @@
                 <p class="card-text">【Basic】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -100,7 +100,7 @@
                 <p class="card-text">【Git】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -108,7 +108,7 @@
                 <p class="card-text">【Git】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -116,7 +116,7 @@
                 <p class="card-text">【Git】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -124,7 +124,7 @@
                 <p class="card-text">【Git】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -132,7 +132,7 @@
                 <p class="card-text">【Git】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -140,7 +140,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -148,7 +148,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -156,7 +156,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -164,7 +164,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -172,7 +172,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -180,7 +180,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -188,7 +188,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -196,7 +196,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -204,7 +204,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -212,7 +212,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -220,7 +220,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -228,7 +228,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -236,7 +236,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -244,7 +244,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -252,7 +252,7 @@
                 <p class="card-text">【Ruby】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -260,7 +260,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -268,7 +268,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -276,7 +276,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -284,7 +284,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -292,7 +292,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -300,7 +300,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -308,7 +308,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -316,7 +316,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -324,7 +324,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -332,7 +332,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -340,7 +340,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -348,7 +348,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -356,7 +356,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -364,7 +364,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -372,7 +372,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -380,7 +380,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -388,7 +388,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -396,7 +396,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -404,7 +404,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -412,7 +412,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -420,7 +420,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -428,7 +428,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -436,7 +436,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -444,7 +444,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -452,7 +452,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -460,7 +460,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -468,7 +468,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -476,7 +476,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -484,7 +484,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -492,7 +492,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -500,7 +500,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -508,7 +508,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -516,7 +516,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -524,7 +524,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -532,7 +532,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -540,7 +540,7 @@
                 <p class="card-text">【Ruby on Rails】</p>
               </div>
             </div>
-            <div class="card col-lg-4 col-md-6">
+            <div class="card col-12 col-md-6 col-lg-4">
               <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
               <div class="card-body">
                 <a href="#" class="btn btn-primary">Go somewhere</a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,61 @@
     <main>
       <%# max_width メソッドは application_helper.rb に記載 %>
       <div class="base-container <%= max_width %>">
+        <h2>Rails テキスト教材</h2>
+        <div class="container">
+          <div class="row">
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Macのショートカットキー</p>
+                <p class="card-text">【Basic】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Linuxコマンド</p>
+                <p class="card-text">【Basic】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Slackを使用したいろんなマークダウン記法</p>
+                <p class="card-text">【Basic】</p>
+              </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Ruby on Rails の環境構築（Mac版）</p>
+                <p class="card-text">【Basic】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">Ruby on Rails 環境構築手順（Windows版）</p>
+                <p class="card-text">【Basic】</p>
+              </div>
+            </div>
+            <div class="card col-lg-4 col-md-6">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <a href="#" class="btn btn-primary">Go somewhere</a>
+                <p class="card-text">環境構築（VSCode）</p>
+                <p class="card-text">【Basic】</p>
+              </div>
+            </div>
+          </div>
+        </div>
         <%= yield %>
       </div>
     </main>


### PR DESCRIPTION
## issue 番号（必須）
​
close #6 
​
## 実装内容

- Railsテキスト教材の一覧ページを作成
  - Bootstrapの Cards や Grid System を用いてスタイルも似せること
  - 画像部分はデフォルト画像を表示するのみとする
  - 検索機能・読破済み機能も別タスクとする
- Railsテキスト教材で表示するジャンルは以下のものとすること

```
["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]
```
- ナビバーのテキスト教材ページへのリンクが機能するようにする
※Take off Railsなどの広告は削ること ※詳細ページへのリンク，詳細ページの作成は別タスクとします
​
​
## 参考資料
​
- [Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)
​
## チェックリスト
​
【補足】プルリクを出した後，クリックでチェックを入れて下さい
​
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
​
## スクリーンショット（必要があれば）
​

​
## 備考（必要があれば）