### PR TITLE
Railsテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,11 @@ gem 'devise'
 gem 'rails-i18n'
 gem 'devise-i18n'
 
+# マークダウン形式で表示するためのgem
+gem 'redcarpet', '~> 2.3.0'
+# シンタックスハイライトに対応させるためのgem
+gem 'coderay'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -253,6 +254,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.4)
   byebug
+  coderay
   devise
   devise-i18n
   jbuilder (~> 2.7)
@@ -263,6 +265,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
   rails-i18n
+  redcarpet (~> 2.3.0)
   sass-rails (>= 6)
   spring
   turbolinks (~> 5)

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -4,6 +4,6 @@ class TextsController < ApplicationController
   end
 
   def show
-    @text = Text.find_by(id: params[:id])
+    @text = Text.find(params[:id])
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -2,4 +2,8 @@ class TextsController < ApplicationController
   def index
     @texts = Text.all
   end
+
+  def show
+    @text = Text.find_by(id: params[:id])
+  end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,19 @@
+module MarkdownHelper
+  def markdown(text)
+    unless @markdown
+      options = {
+        hard_wrap: true,
+      }
+      extensions = {
+        no_intra_emphasis: true,
+        tables: true,
+        fenced_code_blocks: true,
+        autolink: true,
+        quote: true,
+      }
+      renderer = Redcarpet::Render::HTML.new(options)
+      @markdown = Redcarpet::Markdown.new(renderer, extensions)
+    end
+    @markdown.render(text).html_safe
+  end
+end

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -5,13 +5,13 @@
   <div class="row">
     <% @texts.each do |text| %>
       <div class="col-12 col-md-6 col-lg-4 text-card-container">
-        <div class="card">
+        <%= link_to text, class: "card" do %>
           <svg class="bd-placeholder-img card-img-top" width="100%" height="200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
           <div class="card-body">
             <p class="card-text"><%= text.title %></p>
             <p class="card-text"><%= text.genre %></p>
           </div>
-        </div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,2 @@
+<h2><%= @text.title %></h2>
+<%= markdown(@text.content) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   root "texts#index"
+  resources :texts
   resources :movies
   devise_for :users
 end


### PR DESCRIPTION
​
## issue 番号（必須）
​
close #5 
​
## 実装内容
​
Railsテキスト教材詳細ページの実装
gem 'redcarpet' のインストール

## 参考資料

Rails 「Markdown記法の導入について」
​ https://qiita.com/raigakun/items/4ac4aad12f8cf8a0ed94

## チェックリスト
​
【補足】プルリクを出した後，クリックでチェックを入れて下さい
​
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
​
## スクリーンショット（必要があれば）
​
​
## 備考（必要があれば）
